### PR TITLE
changed sphinx-quickstart for Windows

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -13,6 +13,11 @@ set SPHINXPROJ=LibreCAD
 
 if "%1" == "" goto help
 
+if "%1" == "livehtml" (
+	sphinx-autobuild -b html %SOURCEDIR% %BUILDDIR%\html
+	goto end
+)
+
 %SPHINXBUILD% >NUL 2>NUL
 if errorlevel 9009 (
 	echo.


### PR DESCRIPTION
Purpose:
* Allow Read the Docs files to be hosted locally and viewed
* Make edits to the docs themselves and render them locally so you can inspect changes before pushing back to the fork

Install:
* Python 3.7.6 - Note: current bug in v3.8
`pip install Sphinx` - tested with 2.3.1
`pip install sphinx-autobuild` - tested with v0.7.1
`pip install sphinx-rtd-theme` - tested with v0.4.3

Download github.com/LibreCAD/docs and Unzip to a directory
Run as: `make livehtml` from LibreCAD/docs directory
And then visit the webpage served at http://127.0.0.1:8000

Reference: https://github.com/GaretJax/sphinx-autobuild

Credit to @bskinn for this fix as [demonstrated here](https://github.com/bskinn/sphobjinv/blob/58fdea51820f2f3f6e933f935dcc7c3525ff2851/doc/make.bat#L85-L91) and testing with LibreCAD docs