### PR TITLE
Improve wider medium screen responsive layout

### DIFF
--- a/_static/theme_overrides.css
+++ b/_static/theme_overrides.css
@@ -67,3 +67,21 @@
 /* Adjusts indent in tables when forcing line break */
 /* https://stackoverflow.com/questions/34194728/csv-table-formatting-in-python-docstrings-sphinx-multiple-lines-in-one-cell */
 
+
+/* Improve responsive template on wider medium screens
+/* to display more content by displaying hamburger menu icon instead of TOC
+/* https://stackoverflow.com/a/60217315/4539999
+
+@media screen and (max-width: 950px){
+	.wy-body-for-nav{background:#fcfcfc}
+	.wy-nav-top{display:block}
+	.wy-nav-side{left:-300px}
+	.wy-nav-side.shift{width:85%;left:0}
+	.wy-side-scroll{width:auto}
+	.wy-side-nav-search{width:auto}
+	.wy-menu.wy-menu-vertical{width:auto}
+	.wy-nav-content-wrap{margin-left:0}
+	.wy-nav-content-wrap
+	.wy-nav-content{padding:1.618em}
+	.wy-nav-content-wrap.shift{position:fixed;min-width:100%;left:85%;top:0;height:100%;overflow:hidden}
+}


### PR DESCRIPTION
> **The manual is best viewed with a minimum screen width of ...**

It is recognised the existing template displays poorly when the display width is significantly less than the content design width of 700px on a 1100px screen. This template is particularly affected by the poor display issue because:
- the default template max medium screen is relatively narrow
- on the narrowest wide screen less than 50% of the width is available for content
- numerous right-aligned tables display very poorly with constrained content display width

Displaying the hamburger menu icon instead of TOC on wider medium screens displays improves the responsive layout by displaying content closer to design width. It is considered with this change the responsiveness would be so similar to other sites that the warning about _best viewed minimum screen width_ would not be required.

![Default_Medium_Display](https://user-images.githubusercontent.com/11288701/74488616-e51d5100-4f16-11ea-994c-60c789c6dd07.png)
**Default Medium Display**

![Proposed_Medium_Display](https://user-images.githubusercontent.com/11288701/74488623-ea7a9b80-4f16-11ea-9827-71d892bd0845.png)
**Proposed Medium Display**