### PR TITLE
Selection Pointer description change

### DIFF
--- a/ref/menu.rst
+++ b/ref/menu.rst
@@ -67,7 +67,7 @@ Edit
     :class: table-fix-width
 
     "Menu Item", "Icon", "Short-cut / *Command*", "Description"
-    "Selection Pointer", |icon18|, "[Esc] / *k, kill*", "Reverts from current operation to the selection pointer (e.g. cancels the current operation)"
+    "Selection Pointer", |icon18|, "[Esc] / *k, kill*", "Select entity or kill current command."
     "Undo", |icon19|, "[Ctrl]+z / *u, undo, oo*", "Sequentially reverses the previous operations."
     "Redo", |icon20|, "[Ctrl]+[Shift]+z / *r, redo, uu*", "Sequentially reverses the previously reversed operations."
     "Cut", |icon21|, "[Ctrl]+x", "Removes the selected entity (or entities) and places it in temporary memory, e.g. ''clipboard'' for later recall.  A reference point needs to be placed for subsequent paste operations."


### PR DESCRIPTION
In some applications a command is terminated after it is used. A specific mention of _Selection Pointer_ where the concept of _sticky commands_ and how to stop (kill) them is explained is important.