### PR TITLE
DXF2PDF

### DIFF
--- a/guides/console-tool.rst
+++ b/guides/console-tool.rst
@@ -15,4 +15,6 @@ LibreCAD's console tool gives users certain functionality without having to open
 DXF2PDF Tool
 ----------------------
 
-LibreCAD allows convertion of DXF drawings to PDF in console without any need to run the GUI. To do so, users can run ``librecad dxf2pdf [options] ...`` in their command line or terminal. This tool has its own set of options and its own help option which can be obtained by running `librecad dxf2pdf --help`` or `librecad dxf2pdf -h`` (or `librecad dxf2pdf`` with no options at all).
+LibreCAD allows convertion of DXF drawings to PDF in console without any need to run the GUI. To do so, users can run ``librecad dxf2pdf [options] ...`` in their command line or terminal. This tool has its own set of options and its own help option which can be obtained by running `librecad dxf2pdf --help`` or ``librecad dxf2pdf -h`` (or simply ``librecad dxf2pdf`` with no options at all).
+
+In a nutshell, users can use it to convert a DXF file or multiple DXF files to a single multi-page PDF or multiple PDFs.

--- a/guides/console-tool.rst
+++ b/guides/console-tool.rst
@@ -19,9 +19,8 @@ LibreCAD allows convertion of DXF drawings to PDF in console without any need to
 
 In a nutshell, users can use it to convert a DXF file or multiple DXF files to a single multi-page PDF or multiple PDFs. It can be done without specifying any options other than the input filename: ``librecad dxf2pdf file_name.dxf``. The output file is saved in the executable folder under the name of ``file_name.pdf``. If multiple (N) DXF files are selecred (``librecad dxf2pdf file_name1.dxf file_name2.dxf ... file_nameN.dxf``) then N PDF files are made. It is also possible to convert DXF files to PDF and put the results in a single multipage PDF ``outfile.pdf`` as follows: ``librecad dxf2pdf -o outfile.pdf file_name1.dxf file_name2.dxf ... file_nameN.dxf``. The same approach can be used if there is a single DXF file input but the outpit filename needs specification.
 
-There are other options available which can be obtained by running ``librecad dxf2pdf --help`` and at this stage include
+There are other options available which can be obtained by running ``librecad dxf2pdf --help`` and at this stage include::
 
-``
   -h, --help                  Displays help.
   -v, --version               Displays version information.
   -a, --fit                   Auto fit and center drawing to page.
@@ -35,4 +34,3 @@ There are other options available which can be obtained by running ``librecad dx
   -z, --pages <HxV>           Print on multiple pages (Horiz. x Vert.).
   -o, --outfile <file>        Output PDF file.
   -t, --directory <path>      Target output directory.
-``

--- a/guides/console-tool.rst
+++ b/guides/console-tool.rst
@@ -1,0 +1,18 @@
+.. User Manual, LibreCAD v2.2.x
+
+.. Default include
+.. include:: /inclFiles/notice.rst
+
+
+.. _console-tool:
+
+The Console Tool
+================
+
+LibreCAD's console tool gives users certain functionality without having to open the actual GUI version of LibreCAD. To use it, users need to specify options in their console: ``librecad [options] ...``. Running ``librecad --help`` or ``librecad -h`` is a basic option that should show a list of all possible options. Running ``librecad --debug <level>`` or ``librecad -d <level>`` allows launchin LibreCAD in various debug levels from 0 being in no debug level whatsoever and 6 being the debugging level.
+
+
+DXF2PDF Tool
+----------------------
+
+LibreCAD allows convertion of DXF drawings to PDF in console without any need to run the GUI. To do so, users can run ``librecad dxf2pdf [options] ...`` in their command line or terminal. This tool has its own set of options and its own help option which can be obtained by running `librecad dxf2pdf --help`` or `librecad dxf2pdf -h`` (or `librecad dxf2pdf`` with no options at all).

--- a/guides/console-tool.rst
+++ b/guides/console-tool.rst
@@ -17,4 +17,22 @@ DXF2PDF Tool
 
 LibreCAD allows convertion of DXF drawings to PDF in console without any need to run the GUI. To do so, users can run ``librecad dxf2pdf [options] ...`` in their command line or terminal. This tool has its own set of options and its own help option which can be obtained by running `librecad dxf2pdf --help`` or ``librecad dxf2pdf -h`` (or simply ``librecad dxf2pdf`` with no options at all).
 
-In a nutshell, users can use it to convert a DXF file or multiple DXF files to a single multi-page PDF or multiple PDFs.
+In a nutshell, users can use it to convert a DXF file or multiple DXF files to a single multi-page PDF or multiple PDFs. It can be done without specifying any options other than the input filename: ``librecad dxf2pdf file_name.dxf``. The output file is saved in the executable folder under the name of ``file_name.pdf``. If multiple (N) DXF files are selecred (``librecad dxf2pdf file_name1.dxf file_name2.dxf ... file_nameN.dxf``) then N PDF files are made. It is also possible to convert DXF files to PDF and put the results in a single multipage PDF ``outfile.pdf`` as follows: ``librecad dxf2pdf -o outfile.pdf file_name1.dxf file_name2.dxf ... file_nameN.dxf``. The same approach can be used if there is a single DXF file input but the outpit filename needs specification.
+
+There are other options available which can be obtained by running ``librecad dxf2pdf --help`` and at this stage include
+
+``
+  -h, --help                  Displays help.
+  -v, --version               Displays version information.
+  -a, --fit                   Auto fit and center drawing to page.
+  -c, --center                Auto center drawing on page.
+  -k, --grayscale             Print grayscale.
+  -m, --monochrome            Print monochrome (black/white).
+  -p, --paper <WxH>           Paper size (Width x Height) in mm.
+  -r, --resolution <integer>  Output resolution (DPI).
+  -s, --scale <double>        Output scale. E.g.: 0.01 (for 1:100 scale).
+  -f, --margins <L,T,R,B>     Paper margins in mm (integer or float).
+  -z, --pages <HxV>           Print on multiple pages (Horiz. x Vert.).
+  -o, --outfile <file>        Output PDF file.
+  -t, --directory <path>      Target output directory.
+``

--- a/guides/index.rst
+++ b/guides/index.rst
@@ -20,6 +20,7 @@ The example drawings in the **User Guides** use LibreCAD's default configuration
     Drawing Setup <dwg-setup>
     Drawing and Editing <dwg-edit>
     Using the Command Line <cmdline>
+    Using the Console Tool <console-tool>
     Using Blocks <blocks>
     Dimensioning and Text <annotate>
     Completion and Printing <completion>


### PR DESCRIPTION
I decided to include documentation on the DXF2PDF conversion console tool that is present in LibreCAD because there is no information on it here in documentation and I descovered it by accident, while it was preciselly what I was looking for and LibreCAD seems to be the only thing that allows it in console. I hope this helps other people willing to convert DXF files to PDF in console without GUI.

I also made a similar tool for LibreCAD but which allows conversion to PNG, I have the pull request for it [here](https://github.com/LibreCAD/LibreCAD/pull/1293). I am willing to add documentation on it here as well once/if the mentioned pull request is approved.